### PR TITLE
Add symbol groups and SMA indicator

### DIFF
--- a/Sources/Buffett/SymbolGroup.swift
+++ b/Sources/Buffett/SymbolGroup.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Represents a group of related stock symbols.
+public struct SymbolGroup: Codable, Equatable {
+    public var name: String
+    public private(set) var symbols: [Symbol]
+
+    public init(name: String, symbols: [Symbol] = []) {
+        self.name = name
+        self.symbols = symbols
+    }
+
+    /// Adds a symbol to the group if it's not already present.
+    public mutating func add(_ symbol: Symbol) {
+        guard !symbols.contains(symbol) else { return }
+        symbols.append(symbol)
+    }
+
+    /// Removes a symbol from the group if present.
+    public mutating func remove(_ symbol: Symbol) {
+        symbols.removeAll { $0 == symbol }
+    }
+}

--- a/Sources/Buffett/TechnicalIndicators.swift
+++ b/Sources/Buffett/TechnicalIndicators.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Utility to calculate technical indicators.
+public enum TechnicalIndicators {
+    /// Calculates Simple Moving Average (SMA) for an array of values.
+    /// - Parameters:
+    ///   - values: Array of Double values, typically closing prices.
+    ///   - period: Lookback period for the moving average.
+    /// - Returns: Array of optional Double where positions before `period` are `nil`.
+    public static func simpleMovingAverage(values: [Double], period: Int) -> [Double?] {
+        guard period > 0 else { return [] }
+        var results: [Double?] = Array(repeating: nil, count: values.count)
+        var sum: Double = 0
+        for idx in values.indices {
+            sum += values[idx]
+            if idx >= period {
+                sum -= values[idx - period]
+            }
+            if idx >= period - 1 {
+                results[idx] = sum / Double(period)
+            }
+        }
+        return results
+    }
+
+    /// Convenience for OHLCVData arrays using the close price.
+    public static func simpleMovingAverage(for data: [OHLCVData], period: Int) -> [Double?] {
+        let closes = data.map { $0.close }
+        return simpleMovingAverage(values: closes, period: period)
+    }
+}

--- a/Tests/BuffettTests/BuffettTests.swift
+++ b/Tests/BuffettTests/BuffettTests.swift
@@ -18,3 +18,25 @@ func testMockAPI() async throws {
     #expect(chart.count == 1)
     #expect(chart.first?.open == 99.0)
 }
+
+@Test
+func testSymbolGroupAddRemove() {
+    var group = SymbolGroup(name: "Tech")
+    let apple = Symbol(code: "AAPL")
+    group.add(apple)
+    #expect(group.symbols.contains(apple))
+    group.remove(apple)
+    #expect(!group.symbols.contains(apple))
+}
+
+@Test
+func testSMAIndicator() {
+    let values: [Double] = [1, 2, 3, 4, 5]
+    let sma = TechnicalIndicators.simpleMovingAverage(values: values, period: 3)
+    // Expect first two elements to be nil
+    #expect(sma[0] == nil)
+    #expect(sma[1] == nil)
+    #expect(sma[2] == 2.0)
+    #expect(sma[3] == 3.0)
+    #expect(sma[4] == 4.0)
+}


### PR DESCRIPTION
## Summary
- manage groups of symbols with `SymbolGroup`
- add `TechnicalIndicators` with simple moving average logic
- test symbol group and SMA calculations

## Testing
- `swift test`