### PR TITLE
Implement RakutenStockAPI placeholder

### DIFF
--- a/Sources/Buffett/Buffett.swift
+++ b/Sources/Buffett/Buffett.swift
@@ -1,13 +1,6 @@
 import Foundation
 import RakutenStockAPI
 
-/// Protocol defining available stock API methods.
-public protocol StockAPIProtocol: Sendable {
-    func fetchMarketQuote(for symbol: Symbol) async throws -> MarketQuote
-    func fetchTickList(for symbol: Symbol) async throws -> [TickData]
-    func fetchChart(for symbol: Symbol) async throws -> [OHLCVData]
-}
-
 /// Mock implementation used for testing.
 public struct MockStockAPI: StockAPIProtocol, Sendable {
     public init() {}

--- a/Sources/RakutenStockAPI/RakutenStockAPI.swift
+++ b/Sources/RakutenStockAPI/RakutenStockAPI.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Concrete implementation of ``StockAPIProtocol`` backed by Rakuten Securities MarketSpeed II RSS.
+///
+/// This is a placeholder implementation. Actual network calls to the RSS API
+/// should be implemented to fetch real market data.
+public struct RakutenStockAPI: StockAPIProtocol, Sendable {
+    public init() {}
+
+    public func fetchMarketQuote(for symbol: Symbol) async throws -> MarketQuote {
+        // TODO: Replace with real API call to MarketSpeed II RSS.
+        throw NSError(domain: "RakutenStockAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not implemented"])
+    }
+
+    public func fetchTickList(for symbol: Symbol) async throws -> [TickData] {
+        // TODO: Replace with real API call to MarketSpeed II RSS.
+        throw NSError(domain: "RakutenStockAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not implemented"])
+    }
+
+    public func fetchChart(for symbol: Symbol) async throws -> [OHLCVData] {
+        // TODO: Replace with real API call to MarketSpeed II RSS.
+        throw NSError(domain: "RakutenStockAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not implemented"])
+    }
+}

--- a/Sources/RakutenStockAPI/StockAPIProtocol.swift
+++ b/Sources/RakutenStockAPI/StockAPIProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Protocol defining available stock API methods.
+public protocol StockAPIProtocol: Sendable {
+    func fetchMarketQuote(for symbol: Symbol) async throws -> MarketQuote
+    func fetchTickList(for symbol: Symbol) async throws -> [TickData]
+    func fetchChart(for symbol: Symbol) async throws -> [OHLCVData]
+}


### PR DESCRIPTION
## Summary
- move `StockAPIProtocol` to RakutenStockAPI module
- add stub `RakutenStockAPI` struct conforming to the protocol
- adjust existing mock API to use the moved protocol

## Testing
- `swift test`