### PR TITLE
Implement HTTP network calls for RakutenStockAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Buffett is a Swift Package that provides core models, technical indicator utilit
 import Buffett
 import RakutenStockAPI
 
-let api = RakutenStockAPI()
+// Base URL points to a local proxy server that bridges to MarketSpeed II RSS.
+let api = RakutenStockAPI() // or RakutenStockAPI(baseURL: URL(string: "http://localhost:18080")!)
 let symbol = Symbol(code: "7203", name: "Toyota")
 let quote = try await api.fetchMarketQuote(for: symbol)
 print(quote.lastPrice)

--- a/Sources/Buffett/Buffett.swift
+++ b/Sources/Buffett/Buffett.swift
@@ -1,13 +1,6 @@
 import Foundation
 import RakutenStockAPI
 
-/// Protocol defining available stock API methods.
-public protocol StockAPIProtocol: Sendable {
-    func fetchMarketQuote(for symbol: Symbol) async throws -> MarketQuote
-    func fetchTickList(for symbol: Symbol) async throws -> [TickData]
-    func fetchChart(for symbol: Symbol) async throws -> [OHLCVData]
-}
-
 /// Mock implementation used for testing.
 public struct MockStockAPI: StockAPIProtocol, Sendable {
     public init() {}

--- a/Sources/RakutenStockAPI/RakutenStockAPI.swift
+++ b/Sources/RakutenStockAPI/RakutenStockAPI.swift
@@ -1,0 +1,49 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Errors that can be thrown by ``RakutenStockAPI``.
+public enum APIError: Error, Sendable {
+    case invalidResponse
+    case httpError(Int)
+}
+
+/// Concrete implementation of ``StockAPIProtocol`` backed by Rakuten Securities MarketSpeed II RSS.
+///
+/// This implementation performs simple HTTP GET requests to a base URL. The
+/// actual MarketSpeed II RSS endpoints should be proxied via a local server.
+public struct RakutenStockAPI: StockAPIProtocol, Sendable {
+    public var baseURL: URL
+    @preconcurrency public var session: URLSession
+
+    /// Creates an API instance.
+    /// - Parameters:
+    ///   - baseURL: Base URL of the local proxy server.
+    ///   - session: URLSession instance to use. Defaults to ``URLSession.shared``.
+    public init(baseURL: URL = URL(string: "http://localhost:18080")!, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func fetchMarketQuote(for symbol: Symbol) async throws -> MarketQuote {
+        try await request(path: "market/quote/\(symbol.code)")
+    }
+
+    public func fetchTickList(for symbol: Symbol) async throws -> [TickData] {
+        try await request(path: "market/ticks/\(symbol.code)")
+    }
+
+    public func fetchChart(for symbol: Symbol) async throws -> [OHLCVData] {
+        try await request(path: "market/chart/\(symbol.code)")
+    }
+
+    /// Performs an HTTP request and decodes the JSON response.
+    private func request<T: Decodable>(path: String) async throws -> T {
+        let url = baseURL.appendingPathComponent(path)
+        let (data, response) = try await session.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse else { throw APIError.invalidResponse }
+        guard (200..<300).contains(httpResponse.statusCode) else { throw APIError.httpError(httpResponse.statusCode) }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/Sources/RakutenStockAPI/StockAPIProtocol.swift
+++ b/Sources/RakutenStockAPI/StockAPIProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Protocol defining available stock API methods.
+public protocol StockAPIProtocol: Sendable {
+    func fetchMarketQuote(for symbol: Symbol) async throws -> MarketQuote
+    func fetchTickList(for symbol: Symbol) async throws -> [TickData]
+    func fetchChart(for symbol: Symbol) async throws -> [OHLCVData]
+}


### PR DESCRIPTION
## Summary
- implement an HTTP client inside `RakutenStockAPI`
- introduce `APIError` for request failures
- document baseURL usage in README

## Testing
- `swift test`