### PR TITLE
Fix RSI calculation on small datasets

### DIFF
--- a/Sources/Buffett/TechnicalIndicators.swift
+++ b/Sources/Buffett/TechnicalIndicators.swift
@@ -120,9 +120,14 @@ public enum TechnicalIndicators {
     /// - Returns: Array of optional RSI values.
     public static func relativeStrengthIndex(values: [Double], period: Int = 14) -> [Double?] {
         guard period > 0 else { return [] }
+        guard values.count > period else {
+            return Array(repeating: nil, count: values.count)
+        }
+
         var results: [Double?] = Array(repeating: nil, count: values.count)
         var gains: [Double] = Array(repeating: 0, count: values.count)
         var losses: [Double] = Array(repeating: 0, count: values.count)
+
         for i in 1..<values.count {
             let diff = values[i] - values[i - 1]
             if diff >= 0 {
@@ -131,18 +136,19 @@ public enum TechnicalIndicators {
                 losses[i] = -diff
             }
         }
+
         var avgGain = gains[1...period].reduce(0, +) / Double(period)
         var avgLoss = losses[1...period].reduce(0, +) / Double(period)
-        if period < values.count {
-            let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
-            results[period] = 100 - 100 / (1 + rs)
-        }
-        if values.count <= period { return results }
-        for i in (period + 1)..<values.count {
-            avgGain = ((avgGain * Double(period - 1)) + gains[i]) / Double(period)
-            avgLoss = ((avgLoss * Double(period - 1)) + losses[i]) / Double(period)
-            let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
-            results[i] = 100 - 100 / (1 + rs)
+        let initialRS = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
+        results[period] = 100 - 100 / (1 + initialRS)
+
+        if values.count > period + 1 {
+            for i in (period + 1)..<values.count {
+                avgGain = ((avgGain * Double(period - 1)) + gains[i]) / Double(period)
+                avgLoss = ((avgLoss * Double(period - 1)) + losses[i]) / Double(period)
+                let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
+                results[i] = 100 - 100 / (1 + rs)
+            }
         }
         return results
     }

--- a/Tests/BuffettTests/BuffettTests.swift
+++ b/Tests/BuffettTests/BuffettTests.swift
@@ -72,6 +72,13 @@ func testRSIIndicator() {
 }
 
 @Test
+func testRSIInsufficientData() {
+    let values = Array(1...10).map(Double.init)
+    let rsi = TechnicalIndicators.relativeStrengthIndex(values: values, period: 14)
+    #expect(rsi.allSatisfy { $0 == nil })
+}
+
+@Test
 func testBollingerBands() {
     let values: [Double] = [1, 2, 3, 4, 5]
     let bands = TechnicalIndicators.bollingerBands(values: values, period: 3)


### PR DESCRIPTION
## Summary
- protect RSI against period exceeding dataset
- test that RSI returns all `nil` when not enough data

## Testing
- `swift test -q`