### PR TITLE
Add test for RSI with insufficient data

### DIFF
--- a/Sources/Buffett/TechnicalIndicators.swift
+++ b/Sources/Buffett/TechnicalIndicators.swift
@@ -131,13 +131,16 @@ public enum TechnicalIndicators {
                 losses[i] = -diff
             }
         }
+        if values.count <= period {
+            return results
+        }
         var avgGain = gains[1...period].reduce(0, +) / Double(period)
         var avgLoss = losses[1...period].reduce(0, +) / Double(period)
-        if period < values.count {
-            let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
-            results[period] = 100 - 100 / (1 + rs)
+        let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
+        results[period] = 100 - 100 / (1 + rs)
+        if values.count == period + 1 {
+            return results
         }
-        if values.count <= period { return results }
         for i in (period + 1)..<values.count {
             avgGain = ((avgGain * Double(period - 1)) + gains[i]) / Double(period)
             avgLoss = ((avgLoss * Double(period - 1)) + losses[i]) / Double(period)

--- a/Tests/BuffettTests/BuffettTests.swift
+++ b/Tests/BuffettTests/BuffettTests.swift
@@ -72,6 +72,16 @@ func testRSIIndicator() {
 }
 
 @Test
+func testRSIShortData() {
+    let values: [Double] = [1, 2, 3, 4, 5]
+    let rsi = TechnicalIndicators.relativeStrengthIndex(values: values, period: 10)
+    #expect(rsi.count == values.count)
+    for entry in rsi {
+        #expect(entry == nil)
+    }
+}
+
+@Test
 func testBollingerBands() {
     let values: [Double] = [1, 2, 3, 4, 5]
     let bands = TechnicalIndicators.bollingerBands(values: values, period: 3)


### PR DESCRIPTION
## Summary
- adjust RSI calculation to return early when not enough prices are supplied
- add `testRSIShortData` verifying this behavior

## Testing
- `swift test`