### PR TITLE
Refactor indicators into dedicated structs

### DIFF
--- a/Sources/Buffett/BollingerBandsIndicator.swift
+++ b/Sources/Buffett/BollingerBandsIndicator.swift
@@ -1,0 +1,28 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Bollinger Bands.
+public struct BollingerBandsIndicator {
+    /// Calculates bands using raw price values.
+    public static func calculate(values: [Double], period: Int, multiplier: Double = 2.0) -> ([Double?], [Double?], [Double?]) {
+        guard period > 0 else { return ([], [], []) }
+        let sma = SMAIndicator.calculate(values: values, period: period)
+        var upper: [Double?] = Array(repeating: nil, count: values.count)
+        var lower: [Double?] = Array(repeating: nil, count: values.count)
+        for idx in values.indices where idx >= period - 1 {
+            let window = values[(idx - period + 1)...idx]
+            let mean = sma[idx] ?? 0
+            let variance = window.reduce(0) { $0 + pow($1 - mean, 2) } / Double(period)
+            let std = sqrt(variance)
+            upper[idx] = mean + multiplier * std
+            lower[idx] = mean - multiplier * std
+        }
+        return (upper, sma, lower)
+    }
+
+    /// Convenience calculation using `OHLCVData` close prices.
+    public static func calculate(for data: [OHLCVData], period: Int, multiplier: Double = 2.0) -> ([Double?], [Double?], [Double?]) {
+        let closes = data.map { $0.close }
+        return calculate(values: closes, period: period, multiplier: multiplier)
+    }
+}

--- a/Sources/Buffett/EMAIndicator.swift
+++ b/Sources/Buffett/EMAIndicator.swift
@@ -1,0 +1,30 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Exponential Moving Average (EMA).
+public struct EMAIndicator {
+    /// Calculates EMA for an array of `Double` values.
+    public static func calculate(values: [Double], period: Int) -> [Double?] {
+        guard period > 0 else { return [] }
+        var results: [Double?] = Array(repeating: nil, count: values.count)
+        let k = 2.0 / (Double(period) + 1.0)
+        var ema: Double = 0
+        for idx in values.indices {
+            if idx == period - 1 {
+                let sma = values[0...idx].reduce(0, +) / Double(period)
+                ema = sma
+                results[idx] = sma
+            } else if idx >= period {
+                ema = (values[idx] - ema) * k + ema
+                results[idx] = ema
+            }
+        }
+        return results
+    }
+
+    /// Convenience calculation using `OHLCVData` close prices.
+    public static func calculate(for data: [OHLCVData], period: Int) -> [Double?] {
+        let closes = data.map { $0.close }
+        return calculate(values: closes, period: period)
+    }
+}

--- a/Sources/Buffett/IchimokuCloudIndicator.swift
+++ b/Sources/Buffett/IchimokuCloudIndicator.swift
@@ -1,0 +1,49 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Ichimoku Cloud components.
+public struct IchimokuCloudIndicator {
+    /// Returns tuple `(tenkan, kijun, senkouA, senkouB, chikou)` for given data.
+    public static func calculate(for data: [OHLCVData]) -> ([Double?], [Double?], [Double?], [Double?], [Double?]) {
+        let count = data.count
+        var tenkan = [Double?](repeating: nil, count: count)
+        var kijun = [Double?](repeating: nil, count: count)
+        var senkouA = [Double?](repeating: nil, count: count)
+        var senkouB = [Double?](repeating: nil, count: count)
+        var chikou = [Double?](repeating: nil, count: count)
+
+        for i in data.indices {
+            if i >= 8 { // 9-period
+                let highs = data[(i - 8)...i].map { $0.high }
+                let lows = data[(i - 8)...i].map { $0.low }
+                let maxH = highs.max() ?? 0
+                let minL = lows.min() ?? 0
+                tenkan[i] = (maxH + minL) / 2
+            }
+            if i >= 25 { // 26-period
+                let highs = data[(i - 25)...i].map { $0.high }
+                let lows = data[(i - 25)...i].map { $0.low }
+                let maxH = highs.max() ?? 0
+                let minL = lows.min() ?? 0
+                kijun[i] = (maxH + minL) / 2
+            }
+            if i >= 51 { // 52-period
+                let highs = data[(i - 51)...i].map { $0.high }
+                let lows = data[(i - 51)...i].map { $0.low }
+                let maxH = highs.max() ?? 0
+                let minL = lows.min() ?? 0
+                let value = (maxH + minL) / 2
+                if i + 26 < count {
+                    senkouB[i + 26] = value
+                }
+            }
+            if i >= 26 {
+                chikou[i - 26] = data[i].close
+            }
+            if let t = tenkan[i], let k = kijun[i], i + 26 < count {
+                senkouA[i + 26] = (t + k) / 2
+            }
+        }
+        return (tenkan, kijun, senkouA, senkouB, chikou)
+    }
+}

--- a/Sources/Buffett/MACDIndicator.swift
+++ b/Sources/Buffett/MACDIndicator.swift
@@ -1,0 +1,53 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Moving Average Convergence Divergence (MACD).
+public struct MACDIndicator {
+    /// Calculates MACD using raw values.
+    public static func calculate(
+        values: [Double],
+        fastPeriod: Int = 12,
+        slowPeriod: Int = 26,
+        signalPeriod: Int = 9
+    ) -> ([Double?], [Double?]) {
+        let fast = EMAIndicator.calculate(values: values, period: fastPeriod)
+        let slow = EMAIndicator.calculate(values: values, period: slowPeriod)
+        var macd: [Double?] = Array(repeating: nil, count: values.count)
+        for i in values.indices {
+            if let f = fast[i], let s = slow[i] {
+                macd[i] = f - s
+            }
+        }
+        // Compute signal line from non-nil MACD values
+        var macdValues: [Double] = []
+        var macdIndices: [Int] = []
+        for (idx, val) in macd.enumerated() where val != nil {
+            macdValues.append(val!)
+            macdIndices.append(idx)
+        }
+        let signalValues = EMAIndicator.calculate(values: macdValues, period: signalPeriod)
+        var signal: [Double?] = Array(repeating: nil, count: values.count)
+        for (offset, idx) in macdIndices.enumerated() {
+            if offset < signalValues.count {
+                signal[idx] = signalValues[offset]
+            }
+        }
+        return (macd, signal)
+    }
+
+    /// Convenience calculation using `OHLCVData` close prices.
+    public static func calculate(
+        for data: [OHLCVData],
+        fastPeriod: Int = 12,
+        slowPeriod: Int = 26,
+        signalPeriod: Int = 9
+    ) -> ([Double?], [Double?]) {
+        let closes = data.map { $0.close }
+        return calculate(
+            values: closes,
+            fastPeriod: fastPeriod,
+            slowPeriod: slowPeriod,
+            signalPeriod: signalPeriod
+        )
+    }
+}

--- a/Sources/Buffett/RSIIndicator.swift
+++ b/Sources/Buffett/RSIIndicator.swift
@@ -1,0 +1,47 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Relative Strength Index (RSI).
+public struct RSIIndicator {
+    /// Calculates RSI using raw price values.
+    public static func calculate(values: [Double], period: Int = 14) -> [Double?] {
+        guard period > 0 else { return [] }
+        guard values.count > period else {
+            return Array(repeating: nil, count: values.count)
+        }
+
+        var results: [Double?] = Array(repeating: nil, count: values.count)
+        var gains: [Double] = Array(repeating: 0, count: values.count)
+        var losses: [Double] = Array(repeating: 0, count: values.count)
+
+        for i in 1..<values.count {
+            let diff = values[i] - values[i - 1]
+            if diff >= 0 {
+                gains[i] = diff
+            } else {
+                losses[i] = -diff
+            }
+        }
+
+        var avgGain = gains[1...period].reduce(0, +) / Double(period)
+        var avgLoss = losses[1...period].reduce(0, +) / Double(period)
+        let initialRS = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
+        results[period] = 100 - 100 / (1 + initialRS)
+
+        if values.count > period + 1 {
+            for i in (period + 1)..<values.count {
+                avgGain = ((avgGain * Double(period - 1)) + gains[i]) / Double(period)
+                avgLoss = ((avgLoss * Double(period - 1)) + losses[i]) / Double(period)
+                let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
+                results[i] = 100 - 100 / (1 + rs)
+            }
+        }
+        return results
+    }
+
+    /// Convenience calculation using `OHLCVData` close prices.
+    public static func calculate(for data: [OHLCVData], period: Int = 14) -> [Double?] {
+        let closes = data.map { $0.close }
+        return calculate(values: closes, period: period)
+    }
+}

--- a/Sources/Buffett/SMAIndicator.swift
+++ b/Sources/Buffett/SMAIndicator.swift
@@ -1,0 +1,28 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Simple Moving Average (SMA).
+public struct SMAIndicator {
+    /// Calculates SMA for an array of `Double` values.
+    public static func calculate(values: [Double], period: Int) -> [Double?] {
+        guard period > 0 else { return [] }
+        var results: [Double?] = Array(repeating: nil, count: values.count)
+        var sum: Double = 0
+        for idx in values.indices {
+            sum += values[idx]
+            if idx >= period {
+                sum -= values[idx - period]
+            }
+            if idx >= period - 1 {
+                results[idx] = sum / Double(period)
+            }
+        }
+        return results
+    }
+
+    /// Convenience calculation using `OHLCVData` close prices.
+    public static func calculate(for data: [OHLCVData], period: Int) -> [Double?] {
+        let closes = data.map { $0.close }
+        return calculate(values: closes, period: period)
+    }
+}

--- a/Sources/Buffett/TechnicalIndicators.swift
+++ b/Sources/Buffett/TechnicalIndicators.swift
@@ -1,249 +1,63 @@
 import Foundation
 import RakutenStockAPI
 
-/// Utility to calculate technical indicators.
+/// Thin facade to access various technical indicator calculations.
 public enum TechnicalIndicators {
-    /// Calculates Simple Moving Average (SMA) for an array of values.
-    /// - Parameters:
-    ///   - values: Array of Double values, typically closing prices.
-    ///   - period: Lookback period for the moving average.
-    /// - Returns: Array of optional Double where positions before `period` are `nil`.
     public static func simpleMovingAverage(values: [Double], period: Int) -> [Double?] {
-        guard period > 0 else { return [] }
-        var results: [Double?] = Array(repeating: nil, count: values.count)
-        var sum: Double = 0
-        for idx in values.indices {
-            sum += values[idx]
-            if idx >= period {
-                sum -= values[idx - period]
-            }
-            if idx >= period - 1 {
-                results[idx] = sum / Double(period)
-            }
-        }
-        return results
+        SMAIndicator.calculate(values: values, period: period)
     }
 
-    /// Convenience for OHLCVData arrays using the close price.
     public static func simpleMovingAverage(for data: [OHLCVData], period: Int) -> [Double?] {
-        let closes = data.map { $0.close }
-        return simpleMovingAverage(values: closes, period: period)
+        SMAIndicator.calculate(for: data, period: period)
     }
 
-    /// Calculates Exponential Moving Average (EMA) for an array of values.
-    /// - Parameters:
-    ///   - values: Array of Double values.
-    ///   - period: Lookback period for the EMA.
-    /// - Returns: Array of optional Double where positions before `period` are nil.
     public static func exponentialMovingAverage(values: [Double], period: Int) -> [Double?] {
-        guard period > 0 else { return [] }
-        var results: [Double?] = Array(repeating: nil, count: values.count)
-        let k = 2.0 / (Double(period) + 1.0)
-        var ema: Double = 0
-        for idx in values.indices {
-            if idx == period - 1 {
-                let sma = values[0...idx].reduce(0, +) / Double(period)
-                ema = sma
-                results[idx] = sma
-            } else if idx >= period {
-                ema = (values[idx] - ema) * k + ema
-                results[idx] = ema
-            }
-        }
-        return results
+        EMAIndicator.calculate(values: values, period: period)
     }
 
-    /// Convenience for OHLCVData arrays using the close price.
     public static func exponentialMovingAverage(for data: [OHLCVData], period: Int) -> [Double?] {
-        let closes = data.map { $0.close }
-        return exponentialMovingAverage(values: closes, period: period)
+        EMAIndicator.calculate(for: data, period: period)
     }
 
-    /// Calculates MACD (Moving Average Convergence Divergence).
-    /// - Parameters:
-    ///   - values: Input values, typically closing prices.
-    ///   - fastPeriod: Period for the fast EMA.
-    ///   - slowPeriod: Period for the slow EMA.
-    ///   - signalPeriod: Period for the signal line EMA.
-    /// - Returns: Tuple of arrays `(macdLine, signalLine)`.
     public static func movingAverageConvergenceDivergence(
         values: [Double],
         fastPeriod: Int = 12,
         slowPeriod: Int = 26,
         signalPeriod: Int = 9
     ) -> ([Double?], [Double?]) {
-        let fast = exponentialMovingAverage(values: values, period: fastPeriod)
-        let slow = exponentialMovingAverage(values: values, period: slowPeriod)
-        var macd: [Double?] = Array(repeating: nil, count: values.count)
-        for i in values.indices {
-            if let f = fast[i], let s = slow[i] {
-                macd[i] = f - s
-            }
-        }
-        // Compute signal line from non-nil MACD values
-        var macdValues: [Double] = []
-        var macdIndices: [Int] = []
-        for (idx, val) in macd.enumerated() where val != nil {
-            macdValues.append(val!)
-            macdIndices.append(idx)
-        }
-        let signalValues = exponentialMovingAverage(values: macdValues, period: signalPeriod)
-        var signal: [Double?] = Array(repeating: nil, count: values.count)
-        for (offset, idx) in macdIndices.enumerated() {
-            if offset < signalValues.count {
-                signal[idx] = signalValues[offset]
-            }
-        }
-        return (macd, signal)
+        MACDIndicator.calculate(values: values, fastPeriod: fastPeriod, slowPeriod: slowPeriod, signalPeriod: signalPeriod)
     }
 
-    /// Convenience for OHLCVData arrays using the close price.
     public static func movingAverageConvergenceDivergence(
         for data: [OHLCVData],
         fastPeriod: Int = 12,
         slowPeriod: Int = 26,
         signalPeriod: Int = 9
     ) -> ([Double?], [Double?]) {
-        let closes = data.map { $0.close }
-        return movingAverageConvergenceDivergence(
-            values: closes,
-            fastPeriod: fastPeriod,
-            slowPeriod: slowPeriod,
-            signalPeriod: signalPeriod
-        )
+        MACDIndicator.calculate(for: data, fastPeriod: fastPeriod, slowPeriod: slowPeriod, signalPeriod: signalPeriod)
     }
 
-    /// Calculates Relative Strength Index (RSI).
-    /// - Parameters:
-    ///   - values: Input prices.
-    ///   - period: Lookback period (default 14).
-    /// - Returns: Array of optional RSI values.
     public static func relativeStrengthIndex(values: [Double], period: Int = 14) -> [Double?] {
-        guard period > 0 else { return [] }
-        guard values.count > period else {
-            return Array(repeating: nil, count: values.count)
-        }
-
-        var results: [Double?] = Array(repeating: nil, count: values.count)
-        var gains: [Double] = Array(repeating: 0, count: values.count)
-        var losses: [Double] = Array(repeating: 0, count: values.count)
-
-        for i in 1..<values.count {
-            let diff = values[i] - values[i - 1]
-            if diff >= 0 {
-                gains[i] = diff
-            } else {
-                losses[i] = -diff
-            }
-        }
-
-        var avgGain = gains[1...period].reduce(0, +) / Double(period)
-        var avgLoss = losses[1...period].reduce(0, +) / Double(period)
-        let initialRS = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
-        results[period] = 100 - 100 / (1 + initialRS)
-
-        if values.count > period + 1 {
-            for i in (period + 1)..<values.count {
-                avgGain = ((avgGain * Double(period - 1)) + gains[i]) / Double(period)
-                avgLoss = ((avgLoss * Double(period - 1)) + losses[i]) / Double(period)
-                let rs = avgLoss == 0 ? Double.infinity : avgGain / avgLoss
-                results[i] = 100 - 100 / (1 + rs)
-            }
-        }
-        return results
+        RSIIndicator.calculate(values: values, period: period)
     }
 
-    /// Convenience for OHLCVData arrays using the close price.
     public static func relativeStrengthIndex(for data: [OHLCVData], period: Int = 14) -> [Double?] {
-        let closes = data.map { $0.close }
-        return relativeStrengthIndex(values: closes, period: period)
+        RSIIndicator.calculate(for: data, period: period)
     }
 
-    /// Calculates Bollinger Bands.
-    /// - Parameters:
-    ///   - values: Input prices.
-    ///   - period: Moving average period.
-    ///   - multiplier: Standard deviation multiplier (default 2.0).
-    /// - Returns: Tuple `(upper, middle, lower)` bands.
     public static func bollingerBands(values: [Double], period: Int, multiplier: Double = 2.0) -> ([Double?], [Double?], [Double?]) {
-        guard period > 0 else { return ([], [], []) }
-        let sma = simpleMovingAverage(values: values, period: period)
-        var upper: [Double?] = Array(repeating: nil, count: values.count)
-        var lower: [Double?] = Array(repeating: nil, count: values.count)
-        for idx in values.indices where idx >= period - 1 {
-            let window = values[(idx - period + 1)...idx]
-            let mean = sma[idx] ?? 0
-            let variance = window.reduce(0) { $0 + pow($1 - mean, 2) } / Double(period)
-            let std = sqrt(variance)
-            upper[idx] = mean + multiplier * std
-            lower[idx] = mean - multiplier * std
-        }
-        return (upper, sma, lower)
+        BollingerBandsIndicator.calculate(values: values, period: period, multiplier: multiplier)
     }
 
-    /// Convenience for OHLCVData arrays using the close price.
     public static func bollingerBands(for data: [OHLCVData], period: Int, multiplier: Double = 2.0) -> ([Double?], [Double?], [Double?]) {
-        let closes = data.map { $0.close }
-        return bollingerBands(values: closes, period: period, multiplier: multiplier)
+        BollingerBandsIndicator.calculate(for: data, period: period, multiplier: multiplier)
     }
 
-    /// Calculates Ichimoku Cloud components.
-    /// Returns tuple `(tenkan, kijun, senkouA, senkouB, chikou)`.
     public static func ichimokuCloud(for data: [OHLCVData]) -> ([Double?], [Double?], [Double?], [Double?], [Double?]) {
-        let count = data.count
-        var tenkan = [Double?](repeating: nil, count: count)
-        var kijun = [Double?](repeating: nil, count: count)
-        var senkouA = [Double?](repeating: nil, count: count)
-        var senkouB = [Double?](repeating: nil, count: count)
-        var chikou = [Double?](repeating: nil, count: count)
-
-        for i in data.indices {
-            if i >= 8 { // 9-period
-                let highs = data[(i - 8)...i].map { $0.high }
-                let lows = data[(i - 8)...i].map { $0.low }
-                let maxH = highs.max() ?? 0
-                let minL = lows.min() ?? 0
-                tenkan[i] = (maxH + minL) / 2
-            }
-            if i >= 25 { // 26-period
-                let highs = data[(i - 25)...i].map { $0.high }
-                let lows = data[(i - 25)...i].map { $0.low }
-                let maxH = highs.max() ?? 0
-                let minL = lows.min() ?? 0
-                kijun[i] = (maxH + minL) / 2
-            }
-            if i >= 51 { // 52-period
-                let highs = data[(i - 51)...i].map { $0.high }
-                let lows = data[(i - 51)...i].map { $0.low }
-                let maxH = highs.max() ?? 0
-                let minL = lows.min() ?? 0
-                let value = (maxH + minL) / 2
-                if i + 26 < count {
-                    senkouB[i + 26] = value
-                }
-            }
-            if i >= 26 {
-                chikou[i - 26] = data[i].close
-            }
-            if let t = tenkan[i], let k = kijun[i], i + 26 < count {
-                senkouA[i + 26] = (t + k) / 2
-            }
-        }
-        return (tenkan, kijun, senkouA, senkouB, chikou)
+        IchimokuCloudIndicator.calculate(for: data)
     }
 
-    /// Calculates Volume Weighted Average Price (VWAP).
-    /// - Parameter data: OHLCV data array.
-    /// - Returns: Array of VWAP values.
     public static func volumeWeightedAveragePrice(for data: [OHLCVData]) -> [Double?] {
-        var results: [Double?] = Array(repeating: nil, count: data.count)
-        var cumulativePV: Double = 0
-        var cumulativeVolume: Double = 0
-        for (idx, item) in data.enumerated() {
-            cumulativePV += item.close * Double(item.volume)
-            cumulativeVolume += Double(item.volume)
-            results[idx] = cumulativeVolume == 0 ? nil : cumulativePV / cumulativeVolume
-        }
-        return results
+        VWAPIndicator.calculate(for: data)
     }
 }

--- a/Sources/Buffett/VWAPIndicator.swift
+++ b/Sources/Buffett/VWAPIndicator.swift
@@ -1,0 +1,18 @@
+import Foundation
+import RakutenStockAPI
+
+/// Calculates Volume Weighted Average Price (VWAP).
+public struct VWAPIndicator {
+    /// Calculates VWAP using OHLCV data.
+    public static func calculate(for data: [OHLCVData]) -> [Double?] {
+        var results: [Double?] = Array(repeating: nil, count: data.count)
+        var cumulativePV: Double = 0
+        var cumulativeVolume: Double = 0
+        for (idx, item) in data.enumerated() {
+            cumulativePV += item.close * Double(item.volume)
+            cumulativeVolume += Double(item.volume)
+            results[idx] = cumulativeVolume == 0 ? nil : cumulativePV / cumulativeVolume
+        }
+        return results
+    }
+}

--- a/Sources/BuffettUI/ChartViewModel.swift
+++ b/Sources/BuffettUI/ChartViewModel.swift
@@ -35,7 +35,7 @@ public final class ChartViewModel {
 
     /// Recalculate indicator arrays based on current ``data``.
     public func updateIndicators() {
-        sma = TechnicalIndicators.simpleMovingAverage(for: data, period: smaPeriod)
-        ema = TechnicalIndicators.exponentialMovingAverage(for: data, period: emaPeriod)
+        sma = SMAIndicator.calculate(for: data, period: smaPeriod)
+        ema = EMAIndicator.calculate(for: data, period: emaPeriod)
     }
 }

--- a/Tests/BuffettTests/BuffettTests.swift
+++ b/Tests/BuffettTests/BuffettTests.swift
@@ -35,7 +35,7 @@ func testSymbolGroupAddRemove() {
 @Test
 func testSMAIndicator() {
     let values: [Double] = [1, 2, 3, 4, 5]
-    let sma = TechnicalIndicators.simpleMovingAverage(values: values, period: 3)
+    let sma = SMAIndicator.calculate(values: values, period: 3)
     // Expect first two elements to be nil
     #expect(sma[0] == nil)
     #expect(sma[1] == nil)
@@ -47,7 +47,7 @@ func testSMAIndicator() {
 @Test
 func testEMAIndicator() {
     let values: [Double] = [1, 2, 3, 4, 5]
-    let ema = TechnicalIndicators.exponentialMovingAverage(values: values, period: 3)
+    let ema = EMAIndicator.calculate(values: values, period: 3)
     #expect(ema[2] == 2.0)
     #expect(ema[3] == 3.0)
     #expect(ema[4] == 4.0)
@@ -56,7 +56,7 @@ func testEMAIndicator() {
 @Test
 func testMACDIndicator() {
     let values: [Double] = [1, 2, 3, 4, 5, 6, 7]
-    let result = TechnicalIndicators.movingAverageConvergenceDivergence(values: values, fastPeriod: 3, slowPeriod: 5, signalPeriod: 3)
+    let result = MACDIndicator.calculate(values: values, fastPeriod: 3, slowPeriod: 5, signalPeriod: 3)
     let macd = result.0
     let signal = result.1
     #expect(macd[6] != nil)
@@ -66,7 +66,7 @@ func testMACDIndicator() {
 @Test
 func testRSIIndicator() {
     let values = Array(1...15).map(Double.init)
-    let rsi = TechnicalIndicators.relativeStrengthIndex(values: values, period: 14)
+    let rsi = RSIIndicator.calculate(values: values, period: 14)
     let lastWrapped = rsi.last ?? nil
     let last = lastWrapped ?? 0
     #expect(last > 90)
@@ -75,14 +75,14 @@ func testRSIIndicator() {
 @Test
 func testRSIInsufficientData() {
     let values = Array(1...10).map(Double.init)
-    let rsi = TechnicalIndicators.relativeStrengthIndex(values: values, period: 14)
+    let rsi = RSIIndicator.calculate(values: values, period: 14)
     #expect(rsi.allSatisfy { $0 == nil })
 }
 
 @Test
 func testBollingerBands() {
     let values: [Double] = [1, 2, 3, 4, 5]
-    let bands = TechnicalIndicators.bollingerBands(values: values, period: 3)
+    let bands = BollingerBandsIndicator.calculate(values: values, period: 3)
     let upper = bands.0
     let middle = bands.1
     let lower = bands.2
@@ -99,7 +99,7 @@ func testVWAP() {
         .init(symbol: symbol, timestamp: .init(), open: 0, high: 0, low: 0, close: 20, volume: 100),
         .init(symbol: symbol, timestamp: .init(), open: 0, high: 0, low: 0, close: 30, volume: 200)
     ]
-    let vwap = TechnicalIndicators.volumeWeightedAveragePrice(for: data)
+    let vwap = VWAPIndicator.calculate(for: data)
     #expect(vwap[0] == 10)
     #expect(vwap[1] == 15)
     #expect(vwap[2] == 22.5)
@@ -114,7 +114,7 @@ func testIchimokuTenkan() {
         let low = Double(i + 1)
         data.append(OHLCVData(symbol: symbol, timestamp: .init(), open: 0, high: high, low: low, close: high - 1, volume: 0))
     }
-    let ichimoku = TechnicalIndicators.ichimokuCloud(for: data)
+    let ichimoku = IchimokuCloudIndicator.calculate(for: data)
     #expect(ichimoku.0[8] == 6)
 }
 
@@ -122,7 +122,7 @@ func testIchimokuTenkan() {
 func testIchimokuComponentsAll() {
     let symbol = Symbol(code: "ICH")
     let data = Array(repeating: OHLCVData(symbol: symbol, timestamp: .init(), open: 0, high: 10, low: 0, close: 7, volume: 0), count: 80)
-    let ichimoku = TechnicalIndicators.ichimokuCloud(for: data)
+    let ichimoku = IchimokuCloudIndicator.calculate(for: data)
     let tenkan = ichimoku.0
     let kijun = ichimoku.1
     let senkouA = ichimoku.2


### PR DESCRIPTION
## Summary
- break out SMA, EMA, MACD, RSI, Bollinger Bands, Ichimoku, and VWAP indicators into individual structs
- use these new indicator structs from `TechnicalIndicators` as a thin facade
- update `ChartViewModel` to use the new indicator APIs
- adapt unit tests to call the new indicator structs

## Testing
- `swift test`